### PR TITLE
Update inference.py

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -85,6 +85,18 @@ def main():
         default=False,
         help="Use SingleTrackSet if input data is too long.",
     )
+    parser.add_argument(
+        "--save_sgi_params",
+        type=str2bool,
+        default=False,
+        help="Save SGI params for further analysis",
+    )
+    parser.add_argument(
+        "--avoid_clipping",
+        type=str2bool,
+        default=True,
+        help="Forcefully normalize an output by np.abs(wav).max() if there exist some values that exceed 0 dBFS",
+    )
 
     args, _ = parser.parse_known_args()
 


### PR DESCRIPTION
Add missing arguments that were breaking main execution when using separate_func/conv_tasnet_separate.py. I use a local install and have written a script to setup the delimiter easily, and it was not working. It also looks like the demo on the site is facing a runtime error, likely due to something similar.